### PR TITLE
Fix ConfigMap: strict decoding error: unknown field "spec"

### DIFF
--- a/demo/tcp-config-map.yaml
+++ b/demo/tcp-config-map.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Hey,
that project looks great, if I could get it working :)

I discovered tcp-config-map.yaml was missing three dashes, so your demo was broken.
So now there are no more errors.

Unfortunately, it still doesn't show up in tailscale. Would you mind enabling issues on this project, so we can discuss my problem?

This PR fixes the following:

    $ sed "s/\$TS_AUTHKEY/$TS_AUTHKEY/g" * | sudo kubectl apply -f - deployment.apps/demo-backend-deployment created
    serviceaccount/tailscale-ingress-controller created clusterrole.rbac.authorization.k8s.io/tailscale-ingress-controller created clusterrolebinding.rbac.authorization.k8s.io/tailscale-ingress-controller-binding created deployment.apps/tailscale-ingress-controller created serviceaccount/tailscale-ingress-controller unchanged clusterrole.rbac.authorization.k8s.io/tailscale-ingress-controller unchanged clusterrolebinding.rbac.authorization.k8s.io/tailscale-ingress-controller-binding unchanged deployment.apps/tailscale-ingress-controller configured ingress.networking.k8s.io/tailscale-ingress created secret/tailscale-auth created
    Error from server (BadRequest): error when creating "STDIN": ConfigMap in version "v1" cannot be handled as a ConfigMap: strict decoding error: unknown field "spec"