### PR TITLE
Allow for overriding registry when building/pushing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 VARIANT?=latest
 VARIANT_SUFFIX=
+REGISTRY?=valentinalexeev
 
 ifneq (${VARIANT},latest)
 VARIANT_SUFFIX=-${VARIANT}
 endif
 
 build:
-	docker build -t valentinalexeev/tailscale-ingress-controller:${VARIANT} --push .
+	docker build -t ${REGISTRY}/tailscale-ingress-controller:${VARIANT} --push .
 
 deploy:
 	kubectl apply -f demo/ingress-controller${VARIANT_SUFFIX}.yaml


### PR DESCRIPTION
I needed to make a test build, so I can now run `make build REGISTRY=halkeye`